### PR TITLE
ci: note ci is broken & update publish script to use correct token & …

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A demo server will be available to preview the flag comparisons.
 
 ### Publishing new version
 
+## ⚠️ Publish is broken as Travis is no longer used. Please convert the travis & CI Publish script to a GitHub action if you need to publish new version.
+
 Merging to master will cause Travis to run (as long as the commit is not a `chore(release):`
 Commits MUST be conventional commits.
 Travis will publish the new version to artifactory and push the build to Google Cloud Storage on the prod env in the cdn.brandwatch.com bucket. You'll find the assets at `@vizia-assets`

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-git config --global user.email "estocker+gitbot@brandwatch.com"
-git config --global user.name "Vizia CI Bot"
+git config --global user.email "github-actions[bot]@users.noreply.github.com"
+git config --global user.name "github-actions[bot]"
 
 # ensures origin is authed and force on master branch
-git remote set-url origin https://${GH_TOKEN}@github.com/vizia/flags.git
+git remote set-url origin https://${BWBOT_BRANDWATCHLTD_GITHUB_TOKEN}@github.com/vizia/flags.git
 git checkout master
 
 npx standard-version


### PR DESCRIPTION
…git config

this hasnt been published for 5 years at this point, and has no real owner if someone needs to publish this, convert the travis ci to github action I've updated the token to be the token that should be used and the user: BrandwatchBot should be added to the repo as a writer.

issue: https://brandwatch.atlassian.net/browse/AS-336